### PR TITLE
type为datetime时 ranget属性为true时 有默认日期范围 点击问题

### DIFF
--- a/src/laydate.js
+++ b/src/laydate.js
@@ -553,6 +553,11 @@
         that.setValue(that.parse(0, that.systemDate(options.value))); 
       } else {
         that.setValue(options.value); 
+        // friend：@rainbow 添加的代码 start
+        that.startState = true;
+        that.endState = true;
+        // friend：@rainbow 添加的代码 end
+
       }
     }
   };


### PR DESCRIPTION
type为datetime时 ranget属性为true时  默认初始化 value 属性为 ‘2016-08-11 00:00:00 - 2018-12-02 00:00:00’    此时点击控件时已经选定该范围的日期，如果重选 默认的不会清楚，会出现三个小绿方块，数据绑定时会出现问题，添加代码 大概为553行